### PR TITLE
Number of 1 bits in an Unsigned Integer

### DIFF
--- a/HammingWeight.java
+++ b/HammingWeight.java
@@ -1,0 +1,4 @@
+
+public class HammingWeight {
+
+}


### PR DESCRIPTION
Takes an unsigned integer and returns the number of ’1' bits it has (also known as the Hamming weight).